### PR TITLE
Updated the CMakeLists.txt.

### DIFF
--- a/Light/CMakeLists.txt
+++ b/Light/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(Light STATIC ${SOURCES})
 target_include_directories(Light PUBLIC include)
 
 # add OpenGL library
+cmake_policy(SET CMP0072 NEW)
 find_package(OpenGL REQUIRED)
 target_link_libraries(Light ${OPENGL_gl_LIBRARY})
 


### PR DESCRIPTION
Updated the CMakeLists.txt to get rid of the OpenGL warning it was emitting (due to differences in the NEW and OLD  behavior.)

Now, it shouldn't emit an OpenGL warning on Linux anymore.